### PR TITLE
handle iolist properly as it may not be [binary()] always

### DIFF
--- a/src/png.erl
+++ b/src/png.erl
@@ -152,7 +152,7 @@ chunk('IDAT', {raw, Data}) ->
 
 chunk('IDAT', {compressed, CompressedData}) when is_list(CompressedData) ->
     F = fun(Part) ->
-        chunk(<<"IDAT">>, Part) end,
+        chunk(<<"IDAT">>, iolist_to_binary(Part)) end,
     lists:map(F, CompressedData);
 
 chunk('PLTE', {rgb, BitDepth, ColorTuples}) ->


### PR DESCRIPTION
zlib:deflate returns iolist, the current code assumes it will be a
flat list of binary, but that might not be always the case. See below
for a sample error.

```
** (FunctionClauseError) no function clause matching in :png.chunk/2
    (png) src/png.erl:116: :png.chunk("IDAT", [[<<237, 212, 75, 146, 196, 56, 146, 4, 209, 201, 251, 95, 122, 164, 151, 41, 237, 101, 162, 230, 0, 201, 44, 105, 125, 59, 146, 240, 15, 16, 240, 248, 191, 255, 147, 36, 73, 146, 36, 73, 146, 36, 73, 146, 36, 73, 146, 36, ...>>], <<16, 176, 29, 64, 158, 147, 167, 6, 123, 0, 77, 164, 184, 186, 9, 126, 32, 210, 119, 248, 80, 243, 41, 225, 119, 159, 255, 11, 128, 128, 237, 0, 242, 156, 60, 53, 216, 3, 104, 34, 197, 213, 77, 240, 3, 145, 62, 87, ...>>])
    (stdlib) lists.erl:1239: :lists.map/2
    (png) src/png.erl:58: :png.append/2
    (png) src/png.erl:64: :png.close/1
```